### PR TITLE
Prioritise custom css

### DIFF
--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -12,9 +12,6 @@
 
 </style>
 
-<!-- main -->
-<link rel="stylesheet" href="{{ "css/main.css" | absURL }}">
-
 <!-- custom -->
 {{ range .Site.Params.css }} <link rel="stylesheet" href="{{ . | absURL }}"> {{ end }}
 
@@ -29,3 +26,6 @@
 
 <!-- font awesome -->
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+
+<!-- main -->
+<link rel="stylesheet" href="{{ "css/main.css" | absURL }}">


### PR DESCRIPTION
Styles created in `main.css` will be overridden in included libraries if their inclusion follows its own.